### PR TITLE
Fixes the white paper link in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Codius Smart Oracle system
 
-Welcome to Codius. To get started, check out the [Codius whitepaper](https://github.com/codius/codius/wiki/White-Paper) and go to [codius.org](http://codius.org).
+Welcome to Codius. To get started, check out the [Codius whitepaper](https://github.com/codius/codius/wiki/Smart-Oracles:-A-Simple,-Powerful-Approach-to-Smart-Contracts) and go to [codius.org](http://codius.org).


### PR DESCRIPTION
The README currently links to the wrong page. This fixes that.
